### PR TITLE
Prefactor to atoms' gaussians in SOAP

### DIFF
--- a/quippy/quippy/convert.py
+++ b/quippy/quippy/convert.py
@@ -334,7 +334,7 @@ def descriptor_data_mono_to_dict(desc_data_mono):
 
     # fixme: only take the ones actually needed, this is good for debugging now though
     for key in ['has_grad_data', 'ii', 'pos', 'grad_covariance_cutoff', 'covariance_cutoff', 'data', 'has_data',
-                'grad_data', 'ci']:
+                'grad_data', 'ci', 'at_gaussian_weight']:
         take_value(key)
 
     return out_data_dict

--- a/quippy/quippy/convert.py
+++ b/quippy/quippy/convert.py
@@ -49,7 +49,7 @@ def ase_to_quip(ase_atoms: ase.Atoms, quip_atoms=None, add_arrays=None, add_info
         - keys can only be strings, as the fortran dictionary will not accept anything else,\
         integer keys are converted to strings
         - possible types:
-            None - only defaults: pos, Z, cell, pbc, momenta (if exists)
+            None - only defaults: pos, Z, cell, pbc, at_gaussian_weight, momenta (if exists)
             str  - single key
             list - all the list elements are added
             True - all of the arrays
@@ -103,6 +103,9 @@ def ase_to_quip(ase_atoms: ase.Atoms, quip_atoms=None, add_arrays=None, add_info
     quip_atoms.is_periodic[:] = ase_atoms.get_pbc()
     quip_atoms.z[:] = ase_atoms.numbers
     quip_atoms.set_atoms(quip_atoms.z)  # set species and mass
+
+    # make it mandatory. 
+    quip_atoms.at_gaussian_weight = ase_atoms.arrays["at_gaussian_weight"]
 
     if ase_atoms.has('momenta'):
         # if ase atoms has momenta then add velocities to the quip object

--- a/quippy/quippy/descriptors.py
+++ b/quippy/quippy/descriptors.py
@@ -196,7 +196,7 @@ class Descriptor:
         # make numpy arrays out of them
         for key, val in descriptor_out.items():
             # merge the arrays according to shape
-            if key in ['data', 'ci']:
+            if key in ['data', 'ci', 'at_gaussian_weight']:
                 descriptor_out[key] = np.concatenate(val, axis=0)
             elif key in ['covariance_cutoff', 'has_data']:
                 descriptor_out[key] = np.array(val)

--- a/src/libAtoms/Atoms_types.f95
+++ b/src/libAtoms/Atoms_types.f95
@@ -294,7 +294,7 @@ module Atoms_types_module
                                     !%  * ``travel`` Travel across periodic conditions. $(3,N)$ integer array. See meth:`map_into_cell` below.
                                     !%  * ``pos`` $(3,N)$ array of atomic positions, in $\mathrm{\AA}$. Position of atom $i$ is 'pos(:,i)'
                                     !%  * ``mass`` Atomic masses, dimension is $(N)$
-                                    !%  * ``local_q`` Local charges, dimension is $(N)$
+                                    !%  * ``at_gaussian_weight`` Local charges, dimension is $(N)$
                                     !%  * ``velo`` $(3,N)$ array  of atomic velocities, in $\mathrm{AA}$/fs.
                                     !%  * ``acc`` $(3,N)$ array  of accelerations in $\mathrm{AA}$/fs$^2$
                                     !%  * ``avgpos`` $(3,N)$ array  of time-averaged atomic positions.
@@ -333,7 +333,7 @@ module Atoms_types_module
      real(dp), pointer, dimension(:,:) :: pos    => null()  !% $(3,N)$ array of atomic positions, in $\mathrm{AA}$.
                                                             !% Position of atom $i$ is 'pos(:,i)'
      real(dp), pointer, dimension(:)   :: mass   => null()  !% Atomic masses, dimension is actually $(N)$
-     real(dp), pointer, dimension(:)   :: local_q => null() !% Local charges, dimension is $(N)$
+     real(dp), pointer, dimension(:)   :: at_gaussian_weight => null() !% Local charges, dimension is $(N)$
 
      real(dp), pointer, dimension(:,:) :: velo   => null()  !% $(3,N)$ array  of atomic velocities, in $\mathrm{AA}$/fs.
      real(dp), pointer, dimension(:,:) :: acc    => null()  !% $(3,N)$ array  of accelerations in $\mathrm{AA}$/fs$^2$
@@ -494,10 +494,10 @@ contains
              if (this%properties%entries(i)%type /= T_REAL_A) &
                   call system_abort('Confused by Atoms property "mass" not of type T_REAL_A')
              this%mass            => this%properties%entries(i)%r_a(:)
-         case('local_q')
+         case('at_gaussian_weight')
             if (this%properties%entries(i)%type /= T_REAL_A) &
-               call system_abort('Confused by Atoms property "local_q" not of type T_REAL_A')
-            this%local_q            => this%properties%entries(i)%r_a(:)
+               call system_abort('Confused by Atoms property "at_gaussian_weight" not of type T_REAL_A')
+            this%at_gaussian_weight            => this%properties%entries(i)%r_a(:)
  
           case('pos')
              if (this%properties%entries(i)%type /= T_REAL_A2) &
@@ -564,10 +564,10 @@ contains
              if (this%properties%entries(i)%type /= T_REAL_A) &
                   call system_abort('Confused by Atoms property "mass" not of type T_REAL_A')
              this%mass            => this%properties%entries(i)%r_a(1:this%n)
-         case('local_q')
+         case('at_gaussian_weight')
              if (this%properties%entries(i)%type /= T_REAL_A) &
-                  call system_abort('Confused by Atoms property "local_q" not of type T_REAL_A')
-             this%local_q            => this%properties%entries(i)%r_a(1:this%n)
+                  call system_abort('Confused by Atoms property "at_gaussian_weight" not of type T_REAL_A')
+             this%at_gaussian_weight            => this%properties%entries(i)%r_a(1:this%n)
           case('pos')
              if (this%properties%entries(i)%type /= T_REAL_A2) &
                   call system_abort('Confused by Atoms property "mass" not of type T_REAL_A2')

--- a/src/libAtoms/Atoms_types.f95
+++ b/src/libAtoms/Atoms_types.f95
@@ -294,6 +294,7 @@ module Atoms_types_module
                                     !%  * ``travel`` Travel across periodic conditions. $(3,N)$ integer array. See meth:`map_into_cell` below.
                                     !%  * ``pos`` $(3,N)$ array of atomic positions, in $\mathrm{\AA}$. Position of atom $i$ is 'pos(:,i)'
                                     !%  * ``mass`` Atomic masses, dimension is $(N)$
+                                    !%  * ``local_q`` Local charges, dimension is $(N)$
                                     !%  * ``velo`` $(3,N)$ array  of atomic velocities, in $\mathrm{AA}$/fs.
                                     !%  * ``acc`` $(3,N)$ array  of accelerations in $\mathrm{AA}$/fs$^2$
                                     !%  * ``avgpos`` $(3,N)$ array  of time-averaged atomic positions.
@@ -332,6 +333,7 @@ module Atoms_types_module
      real(dp), pointer, dimension(:,:) :: pos    => null()  !% $(3,N)$ array of atomic positions, in $\mathrm{AA}$.
                                                             !% Position of atom $i$ is 'pos(:,i)'
      real(dp), pointer, dimension(:)   :: mass   => null()  !% Atomic masses, dimension is actually $(N)$
+     real(dp), pointer, dimension(:)   :: local_q => null() !% Local charges, dimension is $(N)$
 
      real(dp), pointer, dimension(:,:) :: velo   => null()  !% $(3,N)$ array  of atomic velocities, in $\mathrm{AA}$/fs.
      real(dp), pointer, dimension(:,:) :: acc    => null()  !% $(3,N)$ array  of accelerations in $\mathrm{AA}$/fs$^2$
@@ -492,6 +494,11 @@ contains
              if (this%properties%entries(i)%type /= T_REAL_A) &
                   call system_abort('Confused by Atoms property "mass" not of type T_REAL_A')
              this%mass            => this%properties%entries(i)%r_a(:)
+         case('local_q')
+            if (this%properties%entries(i)%type /= T_REAL_A) &
+               call system_abort('Confused by Atoms property "local_q" not of type T_REAL_A')
+            this%local_q            => this%properties%entries(i)%r_a(:)
+ 
           case('pos')
              if (this%properties%entries(i)%type /= T_REAL_A2) &
                   call system_abort('Confused by Atoms property "mass" not of type T_REAL_A2')
@@ -557,6 +564,10 @@ contains
              if (this%properties%entries(i)%type /= T_REAL_A) &
                   call system_abort('Confused by Atoms property "mass" not of type T_REAL_A')
              this%mass            => this%properties%entries(i)%r_a(1:this%n)
+         case('local_q')
+             if (this%properties%entries(i)%type /= T_REAL_A) &
+                  call system_abort('Confused by Atoms property "local_q" not of type T_REAL_A')
+             this%local_q            => this%properties%entries(i)%r_a(1:this%n)
           case('pos')
              if (this%properties%entries(i)%type /= T_REAL_A2) &
                   call system_abort('Confused by Atoms property "mass" not of type T_REAL_A2')

--- a/src/libAtoms/CInOutput.f95
+++ b/src/libAtoms/CInOutput.f95
@@ -230,7 +230,6 @@ module CInOutput_module
      !%
      !% * **species**, str, 1 col -- atomic species, e.g. Si or H
      !% * **pos**, real, 3 cols -- cartesian positions, in A
-     !% * **local_q**, real, 1 col -- local (per-atom) charge, in e
      !% * **Z**, int, 1 col -- atomic numbers
      !% * **mass**, real, 1 col -- atomic masses, in A,eV,fs units system
      !% * **velo**, real, 3 cols -- velocities, in A/fs

--- a/src/libAtoms/CInOutput.f95
+++ b/src/libAtoms/CInOutput.f95
@@ -230,6 +230,7 @@ module CInOutput_module
      !%
      !% * **species**, str, 1 col -- atomic species, e.g. Si or H
      !% * **pos**, real, 3 cols -- cartesian positions, in A
+     !% * **local_q**, real, 1 col -- local (per-atom) charge, in e
      !% * **Z**, int, 1 col -- atomic numbers
      !% * **mass**, real, 1 col -- atomic masses, in A,eV,fs units system
      !% * **velo**, real, 3 cols -- velocities, in A/fs


### PR DESCRIPTION
Multiply each atomic gaussian in the atomic neighbour density with an array `at_gaussian_weight` read from the input xyz.